### PR TITLE
(iOS) Activate\deactivate  AVAudioSession

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
 # cordova-plugin-audioinput
+
+## This fork (iOS code changed)
+
+This fork from [edimuj/cordova-plugin-audioinput](https://github.com/ddddm/cordova-plugin-audioinput) is made to active/deactivate [AVAudioSession](https://developer.apple.com/reference/avfoundation/avaudiosession?language=objc) in iOS part of this plugin.
+
+Problem (iOS only): if plugin was used while app is running, all audio output will go through the front facing speaker, not through the main speaker, even if you ```audioinput.stop()``` 
+
+Solution: use AVAudioSession's ```setActive``` method to enable\disable audio session.
+
+---
+
 This Cordova plugin enables audio capture from the device microphone, by in (near) real-time forwarding raw audio data to the web layer of your web application.
 A typical usage scenario for this plugin would be to use the captured microphone audio as a source for a Web audio API based applications.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # cordova-plugin-audioinput
-
 This Cordova plugin enables audio capture from the device microphone, by in (near) real-time forwarding raw audio data to the web layer of your web application.
 A typical usage scenario for this plugin would be to use the captured microphone audio as a source for a Web audio API based applications.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,5 @@
 # cordova-plugin-audioinput
 
-## This fork (iOS code changed)
-
-This fork from [edimuj/cordova-plugin-audioinput](https://github.com/ddddm/cordova-plugin-audioinput) is made to active/deactivate [AVAudioSession](https://developer.apple.com/reference/avfoundation/avaudiosession?language=objc) in iOS part of this plugin.
-
-Problem (iOS only): if plugin was used while app is running, all audio output will go through the front facing speaker, not through the main speaker, even if you ```audioinput.stop()``` 
-
-Solution: use AVAudioSession's ```setActive``` method to enable\disable audio session.
-
----
-
 This Cordova plugin enables audio capture from the device microphone, by in (near) real-time forwarding raw audio data to the web layer of your web application.
 A typical usage scenario for this plugin would be to use the captured microphone audio as a source for a Web audio API based applications.
 

--- a/src/ios/AudioReceiver.m
+++ b/src/ios/AudioReceiver.m
@@ -117,6 +117,9 @@ void HandleInputBuffer(void* inUserData,
     _recordState.mCurrentPacket = 0;
     _recordState.mSelf = self;
 
+    AVAudioSession* avSession = [AVAudioSession sharedInstance];
+    [avSession setActive:YES error:nil];
+
     status = AudioQueueNewInput(&_recordState.mDataFormat,
                                 HandleInputBuffer,
                                 &_recordState,
@@ -146,6 +149,10 @@ void HandleInputBuffer(void* inUserData,
     if (_recordState.mIsRunning) {
         AudioQueueStop(_recordState.mQueue, true);
         _recordState.mIsRunning = false;
+
+        AVAudioSession* avSession = [AVAudioSession sharedInstance];
+        [avSession setActive:NO error:nil];
+
     }
 }
 


### PR DESCRIPTION
Problem (iOS only): if the plugin was used while the app is running, all audio output will go through the front facing speaker, not through the main speaker, even if you ```audioinput.stop()``` 

Solution: use AVAudioSession's ```setActive``` method to enable\disable audio session.

Have no experience writing native iOS code but this is what I've read from the [AVAudioSession docs](https://developer.apple.com/reference/avfoundation/avaudiosession?language=objc) and it seems to be working for right now.