### PR TITLE
audio playback should default to the default speaker

### DIFF
--- a/src/ios/AudioReceiver.m
+++ b/src/ios/AudioReceiver.m
@@ -65,7 +65,7 @@ void HandleInputBuffer(void* inUserData,
 
         NSError *setCategoryError = nil;
         if (![avSession setCategory:AVAudioSessionCategoryPlayAndRecord
-         withOptions:AVAudioSessionCategoryOptionMixWithOthers
+         withOptions:AVAudioSessionCategoryOptionMixWithOthers | AVAudioSessionCategoryOptionDefaultToSpeaker
          error:&setCategoryError]) {
             // handle error?
         }


### PR DESCRIPTION
After starting a recording, any sounds played through web audio were defaulting to the ear speaker, rather than the default. Adding this flag when initing `avSession` seems to resolve the problem. 