### PR TITLE
Support recording directly to a given fileUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The plugin supports two different methods for microphone capture:
 ## Supported Platforms
 * Android
 * iOS
+* browser
 
 ## Installation
 From the Cordova Plugin Repository:
@@ -104,8 +105,39 @@ Remember that unfiltered microphone output likely will create a nasty audio feed
 * file-demo - How to encode recorded data to WAV format and save the resulting blob as a file. To run this demo ```cordova plugin add cordova-plugin-file``` is required.
 
 ## API
+**Prepare for capturing audio** from the microphone.
+Performs any required preparation for recording audio on the given platform.
+```javascript
+audioinput.initialize( captureCfg, onInitialized );
+```
+
+**Check whether the module already has permission to access the microphone.
+The callback function has a single boolean argument, which is true if access to the microphone
+has been granted, and false otherwise. The check is passive - the user is not asked for permission
+if they haven't already granted it.
+```javascript
+audioinput.checkMicrophonePermission( onComplete );
+```
+
+**Obtains permission to access the microphone from the user.
+This function will prompt the user for access to the microphone if they haven't already
+granted it.
+The callback function has two arguments:
+ * hasPermission - true if access to the microphone has been granted, and false otherwise.
+ * message - optionally, a reason message, hasPermission is false
+```javascript
+audioinput.getMicrophonePermission( onComplete );
+```
+
 **Start capturing audio** from the microphone.
 If your app doesn't have recording permission on the users device, the plugin will ask for permission when start is called. And the new Android 6.0 runtime permissions are also supported.
+```javascript
+audioinput.initialize( captureCfg );
+```
+
+**Start capturing audio** from the microphone.
+Ensure that initialize and at least checkMicrophonePermission have been called before calling this.
+The captureCfg parameter can include more configuration than previously passed to initialize.
 ```javascript
 audioinput.start( captureCfg );
 ```
@@ -158,7 +190,18 @@ var captureCfg = {
     // -VOICE_COMMUNICATION - Tuned for voice communications such as VoIP.
     // -MIC - Microphone audio source. (Android only)
     // -VOICE_RECOGNITION - Tuned for voice recognition if available (Android only)
-    audioSourceType: audioinput.AUDIOSOURCE_TYPE.DEFAULT
+    audioSourceType: audioinput.AUDIOSOURCE_TYPE.DEFAULT,
+
+    // Optionally specifies a file://... URL to which the audio should be saved.
+    // If this is set, then no audioinput events will be raised during recording.
+    // When stop is called, a single audioinputfinished event will be raised, with
+    // a "file" argument that contains the URL to which the audio was written,
+    // and the callback passed into stop() will be invoked.
+    // Currently, only WAV format files are guaranteed to be supported on all platforms.
+    // When called initialize(), this should be a URL to the directory in which files will
+    // be saved when calling start(), so that initialize() can ensure access to the directory
+    // is available.
+    fileUrl: null
     
 };
 

--- a/README.md
+++ b/README.md
@@ -130,12 +130,6 @@ audioinput.getMicrophonePermission( onComplete );
 ```
 
 **Start capturing audio** from the microphone.
-If your app doesn't have recording permission on the users device, the plugin will ask for permission when start is called. And the new Android 6.0 runtime permissions are also supported.
-```javascript
-audioinput.initialize( captureCfg );
-```
-
-**Start capturing audio** from the microphone.
 Ensure that initialize and at least checkMicrophonePermission have been called before calling this.
 The captureCfg parameter can include more configuration than previously passed to initialize.
 ```javascript

--- a/plugin.xml
+++ b/plugin.xml
@@ -62,7 +62,6 @@
 
     <!-- browser -->
     <platform name="browser">
-      <dependency id="cordova-plugin-file" version="^4.3.4" />
       <config-file parent="/*" target="config.xml">
         <feature name="AudioInputCapture">
           <param name="browser-package" value="AudioInputCapture" />
@@ -71,7 +70,7 @@
       <js-module src="src/browser/AudioInputCaptureProxy.js" name="AudioInputCaptureProxy">
         <runs />
       </js-module>
-      <asset src="src/browser/RecorderWorker.js" target="RecorderWorker.js">
+      <asset src="src/browser/RecorderWorker.js" target=".">
         <runs />
       </asset>
     </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-audioinput"
-        version="0.3.0"
+        version="0.4.0"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -9,8 +9,8 @@
 	<author>Edin Mujkanovic</author>
 	<license>MIT</license>
     <keywords>cordova,phonegap,media,microphone,mic,input,audio,waapi,audionode,web,audio,api,audionode,capture,ios,android</keywords>
-    <repo>https://github.com/edimuj/cordova-plugin-audioinput.git</repo>
-    <issue>https://github.com/edimuj/cordova-plugin-audioinput/issues</issue>
+    <repo>git://github.com/nzilbb/cordova-plugin-audioinput.git</repo>
+    <!--issue>https://github.com/edimuj/cordova-plugin-audioinput/issues</issue-->
 
     <js-module name="AudioInput" src="www/audioInputCapture.js">
         <clobbers target="audioinput" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <plugin id="cordova-plugin-audioinput"
-        version="0.4.0"
+        version="0.5.0"
         xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android">
 
@@ -54,6 +54,22 @@
         <framework src="AudioToolbox.framework" weak="true" />
         <framework src="AVFoundation.framework" weak="true" />
 
+    </platform>
+
+    <!-- browser -->
+    <platform name="browser">
+      <dependency id="cordova-plugin-file" version="^4.3.4" />
+      <config-file parent="/*" target="config.xml">
+        <feature name="AudioInputCapture">
+          <param name="browser-package" value="AudioInputCapture" />
+        </feature>
+      </config-file>
+      <js-module src="src/browser/AudioInputCaptureProxy.js" name="AudioInputCaptureProxy">
+        <runs />
+      </js-module>
+      <asset src="src/browser/RecorderWorker.js" target="RecorderWorker.js">
+        <runs />
+      </asset>
     </platform>
 
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -39,21 +39,25 @@
     <!-- ios -->
     <platform name="ios">
 
-        <config-file parent="/*" target="config.xml">
-            <feature name="AudioInputCapture">
-                <param name="ios-package" value="CDVAudioInputCapture" />
-            </feature>
-        </config-file>
+      <config-file target="*-Info.plist" parent="NSMicrophoneUsageDescription">
+        <string>This app needs microphone access</string>
+      </config-file>
 
-        <source-file src="src/ios/CDVAudioInputCapture.m" />
-        <source-file src="src/ios/AudioReceiver.h" />
-        <source-file src="src/ios/AudioReceiver.m" />
-
-        <framework src="Accelerate.framework" weak="true" />
-        <framework src="CoreAudio.framework" weak="true" />
-        <framework src="AudioToolbox.framework" weak="true" />
-        <framework src="AVFoundation.framework" weak="true" />
-
+      <config-file parent="/*" target="config.xml">
+        <feature name="AudioInputCapture">
+          <param name="ios-package" value="CDVAudioInputCapture" />
+        </feature>
+      </config-file>
+      
+      <source-file src="src/ios/CDVAudioInputCapture.m" />
+      <source-file src="src/ios/AudioReceiver.h" />
+      <source-file src="src/ios/AudioReceiver.m" />
+      
+      <framework src="Accelerate.framework" weak="true" />
+      <framework src="CoreAudio.framework" weak="true" />
+      <framework src="AudioToolbox.framework" weak="true" />
+      <framework src="AVFoundation.framework" weak="true" />
+      
     </platform>
 
     <!-- browser -->

--- a/src/android/AudioInputReceiver.java
+++ b/src/android/AudioInputReceiver.java
@@ -167,6 +167,7 @@ public class AudioInputReceiver extends Thread {
 		os.close();
 		File wav = new File(fileUrl);
 		addWavHeader(audioFile, wav);
+		audioFile.delete();
 		message = handler.obtainMessage();
 		messageBundle = new Bundle();
 		messageBundle.putString("file", wav.toURI().toString());

--- a/src/android/AudioInputReceiver.java
+++ b/src/android/AudioInputReceiver.java
@@ -141,6 +141,7 @@ public class AudioInputReceiver extends Thread {
 	  int numReadBytes = 0;
 	  byte audioBuffer[] = new byte[readBufferSize];
 	  synchronized(this) {
+	     URI finalUrl = fileUrl; // even if the member changes, we use what we were originally given
 	     recorder.startRecording();
 
 	     try
@@ -165,7 +166,7 @@ public class AudioInputReceiver extends Thread {
 		   }
 		} // loop
 		os.close();
-		File wav = new File(fileUrl);
+		File wav = new File(finalUrl);
 		addWavHeader(audioFile, wav);
 		audioFile.delete();
 		message = handler.obtainMessage();
@@ -189,7 +190,7 @@ public class AudioInputReceiver extends Thread {
 	     
 	     recorder.release();
 	     recorder = null;
-	  }
+	  } // syncrhonized
        } // recording to fileUrl
     }
 

--- a/src/browser/AudioInputCaptureProxy.js
+++ b/src/browser/AudioInputCaptureProxy.js
@@ -1,0 +1,340 @@
+/*License (MIT)
+
+Copyright © 2013 Matt Diamond
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of 
+the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO 
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+DEALINGS IN THE SOFTWARE.
+*/
+
+// 2017-10-29 robert@fromont.net.nz Implement as a Cordova plugin for the 'browser' platform
+
+// Public:
+
+function initialize(success, error, opts) {
+    console.log("AudioInputCaptureProxy: initialize: " + JSON.stringify(opts));
+    onInitialized = success;
+    if (!intialized) {
+	sampleRate = opts[0] || sampleRate;
+        bufferSize = opts[1] || bufferSize;
+        channels = opts[2] || channels;
+        format = opts[3] || format;
+        audioSourceType = opts[4] || audioSourceType;
+	fileUrl = opts[5] || fileUrl;
+	
+	if (fileUrl) {
+	    window.requestFileSystem  = window.requestFileSystem || window.webkitRequestFileSystem;
+	    if (window.webkitStorageInfo && window.webkitStorageInfo.requestQuota) { 
+		// Chrome/Android requires calling requestQuota first
+		window.webkitStorageInfo.requestQuota(
+			/file:\/\/\/temporary.*/.test(fileUrl)?window.TEMPORARY:window.PERSISTENT,
+		    10*1024*1024,
+		    function(grantedBytes) {
+			console.log("AudioInputCaptureProxy: Granted " + grantedBytes + " bytes storage");
+			window.requestFileSystem(
+				/file:\/\/\/temporary.*/.test(fileUrl)?window.TEMPORARY:window.PERSISTENT,
+			    10*1024*1024,
+			    function(fs) {
+				console.log("AudioInputCaptureProxy: Got file system: " + fs.name);
+				fileSystem = fs;
+				intialized = true;
+				onInitialized();
+			    }, error);
+		    }, error);
+	    } else {
+		// Firefox and Safari/iOS require calling requestFileSystem directly
+		window.requestFileSystem(
+			/file:\/\/\/temporary.*/.test(fileUrl)?window.TEMPORARY:window.PERSISTENT,
+		    10*1024*1024,
+		    function(fs) {
+			console.log("AudioInputCaptureProxy: Got file system: " + fs.name);
+			fileSystem = fs;
+			intialized = true;
+			onInitialized();
+		    }, error);
+	    }
+	    return;
+	} // fileUrl set
+	intialized = true;
+    } // !initialized
+    onInitialized();
+}
+function checkMicrophonePermission(success, error, opts) {
+    console.log("AudioInputCaptureProxy: checkMicrophonePermission");
+    success(microphonePermission);
+}
+function getMicrophonePermission(success, error, opts) {
+    console.log("AudioInputCaptureProxy: getMicrophonePermission");
+    if (microphonePermission) { // already got permission
+	success(microphonePermission);
+    } else { // start audio processing
+	initAudio(success, error);
+    }
+}
+function start(success, error, opts) {
+    console.log("AudioInputCaptureProxy: start: " + JSON.stringify(opts));
+    sampleRate = opts[0] || sampleRate;
+    bufferSize = opts[1] || bufferSize;
+    channels = opts[2] || channels;
+    format = opts[3] || format;
+    audioSourceType = opts[4] || audioSourceType;
+    fileUrl = opts[5] || fileUrl;
+    console.log("AudioInputCaptureProxy: start - fileUrl: " + fileUrl);
+
+    if (!audioRecorder) {
+	error("Not initialized");
+	return;
+    }
+    audioRecorder.clear();
+    audioRecorder.record();
+
+}
+function stop(success, error, opts) {
+    console.log("AudioInputCaptureProxy: stop");
+    onStopped = success;
+    onStopError = error;
+    audioRecorder.stop();
+    audioRecorder.getBuffers(gotBuffers);
+}
+
+// Private:
+
+var sampleRate = 44100;
+var bufferSize = 1024;
+var channels = 1;
+var format = null;
+var audioSourceType = null;
+var fileUrl = null;
+var intialized = false;
+var microphonePermission = false;
+var audioContext = null;
+var onInitialized = null;
+var onSuccessGotStream = null;
+var onStopped = null;
+var onStopError = null;
+var audioRecorder = null;
+var fileSystem = null;
+
+function initAudio(onSuccess, onError) {
+    console.log("AudioInputCaptureProxy: initAudio");
+    audioContext = new window.AudioContext();
+    if (!navigator.getUserMedia) {
+        navigator.getUserMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia;
+    }
+    if (!navigator.getUserMedia) 
+    {
+	onSuccess(false, "getUserMedia not supported");
+	return;
+    }
+    onSuccessGotStream = onSuccess;
+    navigator.getUserMedia(
+        {
+	    "audio": {
+                "mandatory": {
+		    "googEchoCancellation": "false",
+		    "googAutoGainControl": "false",
+		    "googNoiseSuppression": "false",
+		    "googHighpassFilter": "false"
+                },
+                "optional": []
+	    },
+        }, gotStream, function(e) {
+	    console.log("AudioInputCaptureProxy: " + e);
+	    onSuccess(false, e);
+        });
+} // initiAudio
+
+// callback by web audio when access to the microphone is gained (browser platform)
+function gotStream(stream) {
+    console.log("AudioInputCaptureProxy: gotStream");
+
+    inputPoint = audioContext.createGain();
+
+    // Create an AudioNode from the stream.
+    audioStream = stream;
+    realAudioInput = audioContext.createMediaStreamSource(stream);
+    if (channels = 1) {
+	audioInput = convertToMono( realAudioInput );
+    } else {
+	audioInput = realAudioInput;
+    }
+
+    // we will end up downsampling, but recorderWorker.js does this by simply dropping samples
+    // so we use a low pass filter to prevent aliasing of higher frequencies
+    if (sampleRate < audioContext.sampleRate) {
+	var lowPassFilter = audioContext.createBiquadFilter();
+	audioInput.connect(lowPassFilter);
+	lowPassFilter.connect(inputPoint);
+	lowPassFilter.type = lowPassFilter.LOWPASS||"lowpass";
+	lowPassFilter.frequency.value = sampleRate/2;
+	lowPassFilter.connect(inputPoint);
+    } else {
+	audioInput.connect(inputPoint);
+    }
+    
+    console.log("AudioInputCaptureProxy: creating audioRecorder");
+    audioRecorder = new Recorder( inputPoint, { sampleRate: sampleRate } );
+
+    // pump through zero gain so that the microphone input doesn't play out the speakers causing feedback
+    zeroGain = audioContext.createGain();
+    zeroGain.gain.value = 0.0;
+    inputPoint.connect( zeroGain );
+    zeroGain.connect( audioContext.destination );
+
+    microphonePermission = true;
+    onSuccessGotStream(microphonePermission);
+} // gotStream
+
+function convertToMono( input ) {
+    var splitter = audioContext.createChannelSplitter(2);
+    var merger = audioContext.createChannelMerger(2);
+    
+    input.connect( splitter );
+    splitter.connect( merger, 0, 0 );
+    splitter.connect( merger, 0, 1 );
+    return merger;
+}
+
+// callback from recorder invoked when recordin is finished
+function gotBuffers(wav) {
+    if (channels == 1) {
+	audioRecorder.exportMonoWAV(doneEncoding, wav);
+    } else {
+	audioRecorder.exportWAV(doneEncoding, wav);
+    }
+}
+
+function doneEncoding( blob ) {
+    console.log("AudioInputCaptureProxy: doneEncoding - write to: " + fileUrl);
+    var fileName = fileUrl.replace(/.*\//,"");
+    console.log("AudioInputCaptureProxy: doneEncoding - write to file: " + fileName);
+    fileSystem.root.getFile(fileName, {create: true}, function(fileEntry) {
+	fileEntry.createWriter(function(fileWriter) {		    
+	    fileWriter.onwriteend = function(e) {
+		onStopped(fileUrl);
+	    };		    
+	    fileWriter.onerror = function(e) {
+		console.log("AudioInputCaptureProxy: " + fileUrl + " failed");
+		onStopError(e);
+	    };	    
+	    console.log("AudioInputCaptureProxy: Saving " + fileUrl);
+	    fileWriter.write(blob);
+	}, function(e) {
+	    console.log("AudioInputCaptureProxy: Could not create writer for " + fileUrl);
+	    onStopError(e);
+	}); // createWriter .wav
+    }, function(e) {
+	console.log("AudioInputCaptureProxy: Could not get "+fileUrl+ " -  " + e.toString());
+	onStopError(e);
+    }); // getFile .wav
+}
+
+// 2015-01-28 robert@fromont.net.nz Adding a unique query string ensures it's loaded
+// which in turn ensures the workers starts (in Firefox)
+var WORKER_PATH = 'RecorderWorker.js?' + new Date();
+
+var Recorder = function(source, cfg){
+    var config = cfg || {};
+    var bufferLen = config.bufferLen || 4096;
+    this.context = source.context;
+    if(!this.context.createScriptProcessor){
+	this.node = this.context.createJavaScriptNode(bufferLen, 2, 2);
+    } else {
+	this.node = this.context.createScriptProcessor(bufferLen, 2, 2);
+    }
+    var worker = new Worker(config.workerPath || WORKER_PATH);
+    worker.postMessage({
+	command: 'init',
+	config: {
+            sampleRate: this.context.sampleRate,
+            downsampleRate: config.sampleRate || this.context.sampleRate
+	}
+    });
+    var recording = false,
+	currCallback;
+    
+    this.node.onaudioprocess = function(e){
+	if (!recording) return;
+	worker.postMessage({
+            command: 'record',
+            buffer: [
+		e.inputBuffer.getChannelData(0),
+		e.inputBuffer.getChannelData(1)
+            ]
+	});
+    }
+    
+    this.configure = function(cfg){
+	for (var prop in cfg){
+            if (cfg.hasOwnProperty(prop)){
+		config[prop] = cfg[prop];
+            }
+	}
+    }
+    
+    this.record = function(){
+	recording = true;
+    }
+    
+    this.stop = function(){
+	recording = false;
+    }
+    
+    this.clear = function(){
+	worker.postMessage({ command: 'clear' });
+    }
+    
+    this.getBuffers = function(cb) {
+	currCallback = cb || config.callback;
+	worker.postMessage({ command: 'getBuffers' })
+    }
+    
+    this.exportWAV = function(cb){
+	currCallback = cb || config.callback;
+	type = config.type || 'audio/wav';
+	if (!currCallback) throw new Error('Callback not set');
+	worker.postMessage({
+            command: 'exportWAV',
+            type: type
+	});
+    }
+    
+    this.exportMonoWAV = function(cb){
+	currCallback = cb || config.callback;
+	type = config.type || 'audio/wav';
+	if (!currCallback) throw new Error('Callback not set');
+	worker.postMessage({
+            command: 'exportMonoWAV',
+            type: type
+	});
+    }
+    
+    worker.onmessage = function(e){
+	var blob = e.data;
+	currCallback(blob);
+    }
+    
+    source.connect(this.node);
+    this.node.connect(this.context.destination);   // if the script node is not connected to an output the "onaudioprocess" event is not triggered in chrome.
+};
+
+// 2017-10-29 robert@fromont.net.nz Implement as a Cordova plugin for the 'browser' platform
+// Define module exports:
+module.exports = {
+    initialize: initialize,
+    checkMicrophonePermission: checkMicrophonePermission,
+    getMicrophonePermission: getMicrophonePermission,
+    start: start,
+    stop: stop
+};
+require('cordova/exec/proxy').add('AudioInputCapture', module.exports);

--- a/src/browser/AudioInputCaptureProxy.js
+++ b/src/browser/AudioInputCaptureProxy.js
@@ -89,6 +89,8 @@ function start(success, error, opts) {
     format = opts[3] || format;
     audioSourceType = opts[4] || audioSourceType;
     fileUrl = opts[5] || fileUrl;
+    // the URL must be converted to a cdvfile:... URL to ensure it's readable from the outside
+    fileUrl = fileUrl.replace("filesystem:file:///", "cdvfile://localhost/");
     console.log("AudioInputCaptureProxy: start - fileUrl: " + fileUrl);
 
     if (!audioRecorder) {

--- a/src/browser/RecorderWorker.js
+++ b/src/browser/RecorderWorker.js
@@ -1,0 +1,185 @@
+/*License (MIT)
+
+Copyright © 2013 Matt Diamond
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of 
+the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO 
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+DEALINGS IN THE SOFTWARE.
+*/
+var recLength = 0,
+  recBuffersL = [],
+  recBuffersR = [],
+  sampleRate,
+  downsampleRate;
+
+this.onmessage = function(e){
+  switch(e.data.command){
+    case 'init':
+      init(e.data.config);
+      break;
+    case 'record':
+      record(e.data.buffer);
+      break;
+    case 'exportWAV':
+      exportWAV(e.data.type);
+      break;
+    case 'exportMonoWAV':
+      exportMonoWAV(e.data.type);
+      break;
+    case 'getBuffers':
+      getBuffers();
+      break;
+    case 'clear':
+      clear();
+      break;
+  }
+};
+
+function init(config){
+  sampleRate = config.sampleRate;
+  downsampleRate = config.downsampleRate || config.sampleRate;
+}
+
+function record(inputBuffer){
+  recBuffersL.push(inputBuffer[0]);
+  recBuffersR.push(inputBuffer[1]);
+  recLength += inputBuffer[0].length;
+}
+
+function exportWAV(type){
+  var bufferL = mergeBuffers(recBuffersL, recLength);
+  var bufferR = mergeBuffers(recBuffersR, recLength);
+  var interleaved = interleave(
+      downsample(bufferL, sampleRate, downsampleRate), 
+      downsample(bufferR, sampleRate, downsampleRate));
+  var dataview = encodeWAV(interleaved);
+  var audioBlob = new Blob([dataview], { type: type });
+
+  this.postMessage(audioBlob);
+}
+
+function exportMonoWAV(type){
+  var bufferL = mergeBuffers(recBuffersL, recLength);
+  var dataview = encodeWAV(downsample(bufferL, sampleRate, downsampleRate), true);
+  var audioBlob = new Blob([dataview], { type: type });
+
+  this.postMessage(audioBlob);
+}
+
+function getBuffers() {
+  var buffers = [];
+  buffers.push( mergeBuffers(recBuffersL, recLength) );
+  buffers.push( mergeBuffers(recBuffersR, recLength) );
+  this.postMessage(buffers);
+}
+
+function clear(){
+  recLength = 0;
+  recBuffersL = [];
+  recBuffersR = [];
+}
+
+function mergeBuffers(recBuffers, recLength){
+  var result = new Float32Array(recLength);
+  var offset = 0;
+  for (var i = 0; i < recBuffers.length; i++){
+    result.set(recBuffers[i], offset);
+    offset += recBuffers[i].length;
+  }
+  return result;
+}
+
+function interleave(inputL, inputR){
+  var length = inputL.length + inputR.length;
+  var result = new Float32Array(length);
+
+  var index = 0,
+    inputIndex = 0;
+
+  while (index < length){
+    result[index++] = inputL[inputIndex];
+    result[index++] = inputR[inputIndex];
+    inputIndex++;
+  }
+  return result;
+}
+
+// thanks to http://stackoverflow.com/questions/31818112/downsample-pcm-audio-from-44100-to-8000
+function downsample(e, sampleRate, outputSampleRate){
+    if (sampleRate <= outputSampleRate) return e;
+
+    var t = e.length;
+    sampleRate += 0.0;
+    outputSampleRate += 0.0;
+    var s = 0,
+    o = sampleRate / outputSampleRate,
+    u = Math.ceil(t * outputSampleRate / sampleRate),
+    a = new Float32Array(u);
+    for (i = 0; i < u; i++) {
+        a[i] = e[Math.floor(s)];
+        s += o;
+    }
+    
+    return a;
+}
+
+function floatTo16BitPCM(output, offset, input){
+  for (var i = 0; i < input.length; i++, offset+=2){
+    var s = Math.max(-1, Math.min(1, input[i]));
+    output.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7FFF, true);
+  }
+}
+
+function writeString(view, offset, string){
+  for (var i = 0; i < string.length; i++){
+    view.setUint8(offset + i, string.charCodeAt(i));
+  }
+}
+
+function encodeWAV(samples, mono){
+  var buffer = new ArrayBuffer(44 + samples.length * 2);
+  var view = new DataView(buffer);
+
+  /* RIFF identifier */
+  writeString(view, 0, 'RIFF');
+  /* file length */
+  view.setUint32(4, 32 + samples.length * 2, true);
+  /* RIFF type */
+  writeString(view, 8, 'WAVE');
+  /* format chunk identifier */
+  writeString(view, 12, 'fmt ');
+  /* format chunk length */
+  view.setUint32(16, 16, true);
+  /* sample format (raw) */
+  view.setUint16(20, 1, true);
+  /* channel count */
+  var channelCount = mono?1:2;
+  view.setUint16(22, channelCount, true);
+  /* sample rate */
+  view.setUint32(24, downsampleRate, true);
+  var blockAlign = channelCount * 2; // 2 = bytes per sample
+  /* byte rate (sample rate * block align) */
+  view.setUint32(28, downsampleRate * blockAlign, true);
+  /* block align (channel count * bytes per sample) */
+  view.setUint16(32, blockAlign, true);
+  /* bits per sample */
+  view.setUint16(34, 16, true);
+  /* data chunk identifier */
+  writeString(view, 36, 'data');
+  /* data chunk length */
+  view.setUint32(40, samples.length * 2, true);
+
+  floatTo16BitPCM(view, 44, samples);
+
+  return view;
+}

--- a/src/ios/AudioReceiver.h
+++ b/src/ios/AudioReceiver.h
@@ -32,7 +32,7 @@ typedef struct {
 
     @property (nonatomic, assign) AQRecordState recordState;
     @property (nonatomic, strong) AVAudioRecorder *audioRecorder;
-    @property (nonatomic, strong) NSString* fileUrl;
+    @property (nonatomic, strong) NSURL* fileUrl;
     @property (nonatomic, strong) NSString* filePath;
 
     @property (nonatomic) int mySampleRate;

--- a/src/ios/AudioReceiver.h
+++ b/src/ios/AudioReceiver.h
@@ -31,6 +31,9 @@ typedef struct {
     @property (nonatomic, assign) id delegate;
 
     @property (nonatomic, assign) AQRecordState recordState;
+    @property (nonatomic, strong) AVAudioRecorder *audioRecorder;
+    @property (nonatomic, strong) NSString* fileUrl;
+    @property (nonatomic, strong) NSString* filePath;
 
     @property (nonatomic) int mySampleRate;
     @property (nonatomic) int myBufferSize;
@@ -42,7 +45,7 @@ typedef struct {
 - (void)stop;
 - (void)pause;
 - (void)dealloc;
-- (AudioReceiver*)init:(int)sampleRate bufferSize:(int)bufferSizeInBytes noOfChannels:(short)channels audioFormat:(NSString*)format sourceType:(int)audioSourceType;
+- (AudioReceiver*)init:(int)sampleRate bufferSize:(int)bufferSizeInBytes noOfChannels:(short)channels audioFormat:(NSString*)format sourceType:(int)audioSourceType fileUrl:(NSString*)url;
 - (void)didReceiveAudioData:(short*)samples dataLength:(int)length;
 - (void)hasError:(int)statusCode:(char*)file:(int)line;
 

--- a/src/ios/AudioReceiver.h
+++ b/src/ios/AudioReceiver.h
@@ -33,6 +33,7 @@ typedef struct {
     @property (nonatomic, assign) AQRecordState recordState;
     @property (nonatomic, strong) AVAudioRecorder *audioRecorder;
     @property (nonatomic, strong) NSURL* fileUrl;
+    @property (nonatomic, strong) NSURL* startedFileUrl;
     @property (nonatomic, strong) NSString* filePath;
 
     @property (nonatomic) int mySampleRate;

--- a/src/ios/AudioReceiver.m
+++ b/src/ios/AudioReceiver.m
@@ -125,7 +125,12 @@ void HandleInputBuffer(void* inUserData,
 
 
 - (void) startRecording{
+  NSLog(@"[INFO] startRecording: %d", _recordState.mIsRunning);
     OSStatus status = noErr;
+
+    if (_recordState.mIsRunning == YES) {
+      [self stop];
+    }
 
     if (_fileUrl == nil) {
       _recordState.mCurrentPacket = 0;
@@ -153,16 +158,7 @@ void HandleInputBuffer(void* inUserData,
       [self hasError:status:__FILE__:__LINE__];
 
     } else { /* recording direct to file */
-    
-      if (_audioRecorder != nil)
-      {
-	if (_audioRecorder.recording)
-	{
-	  [_audioRecorder stop];
-	}
-	/* [_audioRecorder dealloc]; TODO */
-      }
-      
+          
       NSDictionary *recordingSettings = @{AVFormatIDKey : @(kAudioFormatLinearPCM),
                                         AVNumberOfChannelsKey : @(_recordState.mDataFormat.mChannelsPerFrame),
                                         AVSampleRateKey : @(_recordState.mDataFormat.mSampleRate),
@@ -201,6 +197,7 @@ void HandleInputBuffer(void* inUserData,
 	  NSLog(@"[INFO] iosaudiorecorder:Recording...");
 	}
       }
+      _startedFileUrl = _fileUrl;
     } /* recording direct to file */
 }
 
@@ -208,16 +205,18 @@ void HandleInputBuffer(void* inUserData,
     Stop Audio Input capture
  */
 - (void)stop {
-
+  NSLog(@"[INFO] stop: %d", _recordState.mIsRunning);
+	  
     if (_recordState.mIsRunning) {
+      _recordState.mIsRunning = false;      
       if (_fileUrl == nil) {
         AudioQueueStop(_recordState.mQueue, true);
       } else {
 	[_audioRecorder stop];
-	[self didFinish:_fileUrl.absoluteString];
+	[self didFinish:_startedFileUrl.absoluteString];
       }
-      _recordState.mIsRunning = false;      
     }
+  NSLog(@"[INFO] stopped: %d", _recordState.mIsRunning);
 }
 
 

--- a/src/ios/AudioReceiver.m
+++ b/src/ios/AudioReceiver.m
@@ -100,7 +100,6 @@ void HandleInputBuffer(void* inUserData,
 
 	// assign fileUrl
 	_fileUrl = url;
-        _filePath = _fileUrl.path;
     }
 
     return self;
@@ -144,7 +143,8 @@ void HandleInputBuffer(void* inUserData,
     [self hasError:status:__FILE__:__LINE__];
     */
     
-    NSURL *soundFileURL = [NSURL URLWithString:[_myFileUrl stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+    NSURL *soundFileURL = [NSURL URLWithString:[_fileUrl stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+    _filePath = soundFileURL.path;
 
     if (_audioRecorder != nil)
     {
@@ -152,8 +152,18 @@ void HandleInputBuffer(void* inUserData,
       {
 	[_audioRecorder stop];
       }
-      [_audioRecorder dealloc];
+      /* [_audioRecorder dealloc]; TODO */
     }
+    
+    NSDictionary *recordingSettings = @{AVFormatIDKey : @(kAudioFormatLinearPCM),
+                                        AVNumberOfChannelsKey : @(_recordState.mDataFormat.mChannelsPerFrame),
+                                        AVSampleRateKey : @(_recordState.mDataFormat.mSampleRate),
+                                        AVLinearPCMBitDepthKey : @(16),
+                                        AVLinearPCMIsBigEndianKey : @NO,
+                                        //AVLinearPCMIsNonInterleaved : @YES,
+                                        AVLinearPCMIsFloatKey : @NO,
+                                        AVEncoderAudioQualityKey : @(AVAudioQualityMax)
+                                        };
     
     NSError *error = nil;
     
@@ -191,7 +201,7 @@ void HandleInputBuffer(void* inUserData,
 	[_audioRecorder stop];
         _recordState.mIsRunning = false;
 
-	[self didFinish:url];
+	[self didFinish:_fileUrl];
 
     }
 }
@@ -238,7 +248,7 @@ void HandleInputBuffer(void* inUserData,
     Finished
  */
 - (void)didFinish:(NSString*)file {
-    [self.delegate didfinish:file];
+    [self.delegate didFinish:file];
 }
 
 

--- a/src/ios/CDVAudioInputCapture.m
+++ b/src/ios/CDVAudioInputCapture.m
@@ -192,13 +192,17 @@
 
 - (void)didEnterBackground
 {
-    [self.audioReceiver pause];
+  // only pause recording when we go into the background if we're not recording to a file
+  // (otherwis it generates a spurious finished event, and starting again when in the foreground resets the file)
+  if (_fileUrl == nil) [self.audioReceiver pause];
 }
 
 
 - (void)willEnterForeground
 {
-    [self.audioReceiver start];
+  // only start recording when we go into the foreground if we're not recording to a file
+  // (otherwise starting again resets the file)
+  if (_fileUrl == nil) [self.audioReceiver start];
 }
 
 @end

--- a/src/ios/CDVAudioInputCapture.m
+++ b/src/ios/CDVAudioInputCapture.m
@@ -36,6 +36,37 @@
                    object:nil];
 }
 
+- (void)initialize:(CDVInvokedUrlCommand*)command
+{
+    _fileUrl = [command.arguments objectAtIndex:5];
+    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:nil];
+    [result setKeepCallbackAsBool:NO];
+    [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+}
+
+- (void)checkMicrophonePermission:(CDVInvokedUrlCommand*)command
+{
+  BOOL hasPermission = FALSE;
+  if ([[AVAudioSession sharedInstance] recordPermission] == AVAudioSessionRecordPermissionGranted) {
+    hasPermission = TRUE;
+  }
+  CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:hasPermission];
+  [result setKeepCallbackAsBool:NO];
+  [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+}
+
+- (void)getMicrophonePermission:(CDVInvokedUrlCommand*)command
+{
+  [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
+      NSLog(@"permission : %d", granted);
+      
+      CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:granted];
+      [result setKeepCallbackAsBool:NO];
+      [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+    }];
+}
+
+
 
 - (void)start:(CDVInvokedUrlCommand*)command
 {

--- a/src/ios/CDVAudioInputCapture.m
+++ b/src/ios/CDVAudioInputCapture.m
@@ -68,7 +68,7 @@
 
         if (self.callbackId) {
             CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:0.0f];
-            [result setKeepCallbackAsBool:NO];
+            [result setKeepCallbackAsBool:YES]; /* TODO NO]; */
             [self.commandDelegate sendPluginResult:result callbackId:self.callbackId];
         }
 

--- a/www/audioInputCapture.js
+++ b/www/audioInputCapture.js
@@ -52,6 +52,74 @@ audioinput.DEFAULT = {
 };
 
 /**
+ * Does any initialization that might be required.
+ *
+ * @param {Callback} onComplete
+ */
+audioinput.initialize = function (cfg, onComplete) {
+    console.log("audioinput.initialize");
+    if (!cfg) {
+        cfg = {};
+    }    
+    audioinput._cfg = {};
+    audioinput._cfg.sampleRate = cfg.sampleRate || audioinput.DEFAULT.SAMPLERATE;
+    audioinput._cfg.bufferSize = cfg.bufferSize || audioinput.DEFAULT.BUFFER_SIZE;
+    audioinput._cfg.channels = cfg.channels || audioinput.DEFAULT.CHANNELS;
+    audioinput._cfg.format = cfg.format || audioinput.DEFAULT.FORMAT;
+    audioinput._cfg.normalize = typeof cfg.normalize == 'boolean' ? cfg.normalize : audioinput.DEFAULT.NORMALIZE;
+    audioinput._cfg.normalizationFactor = cfg.normalizationFactor || audioinput.DEFAULT.NORMALIZATION_FACTOR;
+    audioinput._cfg.streamToWebAudio = typeof cfg.streamToWebAudio == 'boolean' ? cfg.streamToWebAudio : audioinput.DEFAULT.STREAM_TO_WEBAUDIO;
+    audioinput._cfg.audioContext = cfg.audioContext || null;
+    audioinput._cfg.concatenateMaxChunks = cfg.concatenateMaxChunks || audioinput.DEFAULT.CONCATENATE_MAX_CHUNKS;
+    audioinput._cfg.audioSourceType = cfg.audioSourceType || 0;
+    audioinput._cfg.fileUrl = cfg.fileUrl || null;
+    
+    if (audioinput._cfg.channels < 1 && audioinput._cfg.channels > 2) {
+        throw "Invalid number of channels (" + audioinput._cfg.channels + "). Only mono (1) and stereo (2) is" +
+            " supported.";
+    }
+    else if (audioinput._cfg.format != "PCM_16BIT" && audioinput._cfg.format != "PCM_8BIT") {
+        throw "Invalid format (" + audioinput._cfg.format + "). Only 'PCM_8BIT' and 'PCM_16BIT' is" +
+            " supported.";
+    }
+    
+    if (audioinput._cfg.bufferSize <= 0) {
+        throw "Invalid bufferSize (" + audioinput._cfg.bufferSize + "). Must be greater than zero.";
+    }
+    
+    if (audioinput._cfg.concatenateMaxChunks <= 0) {
+        throw "Invalid concatenateMaxChunks (" + audioinput._cfg.concatenateMaxChunks + "). Must be greater than zero.";
+    }
+    exec(onComplete, audioinput._audioInputErrorEvent, "AudioInputCapture", "initialize",
+	 [audioinput._cfg.sampleRate,
+          audioinput._cfg.bufferSize,
+          audioinput._cfg.channels,
+          audioinput._cfg.format,
+          audioinput._cfg.audioSourceType,
+          audioinput._cfg.fileUrl]);
+}
+
+/**
+ * Checks (silently) whether the user has already given permission to access the microphone.
+ *
+ * @param {Callback} onComplete
+ */
+audioinput.checkMicrophonePermission = function (onComplete) {
+    console.log("audioinput.checkMicrophonePermission");
+    exec(onComplete, audioinput._audioInputErrorEvent, "AudioInputCapture", "checkMicrophonePermission", []);
+}
+
+/**
+ * Asks the user for permission to access the microphone.
+ *
+ * @param {Callback} onComplete
+ */
+audioinput.getMicrophonePermission = function (onComplete) {
+    console.log("audioinput.getMicrophonePermission");
+    exec(onComplete, audioinput._audioInputErrorEvent, "AudioInputCapture", "getMicrophonePermission", []);
+}
+
+/**
  * Start capture of Audio input
  *
  * @param {Object} cfg
@@ -68,13 +136,14 @@ audioinput.DEFAULT = {
  *  audioSourceType (Use audioinput.AUDIOSOURCE_TYPE.)
  */
 audioinput.start = function (cfg) {
+    console.log("audioinput.start");
     if (!audioinput._capturing) {
 
         if (!cfg) {
             cfg = {};
         }
 
-        audioinput._cfg = {};
+        if (!audioinput._cfg) audioinput._cfg = {};
         audioinput._cfg.sampleRate = cfg.sampleRate || audioinput.DEFAULT.SAMPLERATE;
         audioinput._cfg.bufferSize = cfg.bufferSize || audioinput.DEFAULT.BUFFER_SIZE;
         audioinput._cfg.channels = cfg.channels || audioinput.DEFAULT.CHANNELS;
@@ -133,9 +202,10 @@ audioinput.start = function (cfg) {
 /**
  * Stop capturing audio
  */
-audioinput.stop = function () {
+audioinput.stop = function (onStopped) {
+    console.log("audioinput.stop");
     if (audioinput._capturing) {
-        exec(null, audioinput._audioInputErrorEvent, "AudioInputCapture", "stop", []);
+        exec(onStopped, audioinput._audioInputErrorEvent, "AudioInputCapture", "stop", []);
         audioinput._capturing = false;
     }
 
@@ -146,7 +216,6 @@ audioinput.stop = function () {
         audioinput._audioDataQueue = null;
     }
 };
-
 
 /**
  * Connect the audio node

--- a/www/audioInputCapture.js
+++ b/www/audioInputCapture.js
@@ -85,6 +85,7 @@ audioinput.start = function (cfg) {
         audioinput._cfg.audioContext = cfg.audioContext || null;
         audioinput._cfg.concatenateMaxChunks = cfg.concatenateMaxChunks || audioinput.DEFAULT.CONCATENATE_MAX_CHUNKS;
         audioinput._cfg.audioSourceType = cfg.audioSourceType || 0;
+        audioinput._cfg.fileUrl = cfg.fileUrl || null;
 
         if (audioinput._cfg.channels < 1 && audioinput._cfg.channels > 2) {
             throw "Invalid number of channels (" + audioinput._cfg.channels + "). Only mono (1) and stereo (2) is" +
@@ -108,7 +109,8 @@ audioinput.start = function (cfg) {
              audioinput._cfg.bufferSize,
              audioinput._cfg.channels,
              audioinput._cfg.format,
-             audioinput._cfg.audioSourceType]);
+             audioinput._cfg.audioSourceType,
+             audioinput._cfg.fileUrl]);
 
         audioinput._capturing = true;
 
@@ -224,6 +226,9 @@ audioinput._audioInputEvent = function (audioInputData) {
         }
         else if (audioInputData && audioInputData.error) {
             audioinput._audioInputErrorEvent(audioInputData.error);
+	}
+        else if (audioInputData && audioInputData.file) {
+            audioinput._audioInputFinishedEvent(audioInputData.file);
         }
     }
     catch (ex) {
@@ -238,6 +243,15 @@ audioinput._audioInputEvent = function (audioInputData) {
 
 audioinput._audioInputErrorEvent = function (e) {
     cordova.fireWindowEvent("audioinputerror", {message: e});
+};
+
+/**
+ * Finished callback for AudioInputCapture start
+ * @private
+ */
+
+audioinput._audioInputFinishedEvent = function (fileUrl) {
+    cordova.fireWindowEvent("audioinputfinished", {file: fileUrl});
 };
 
 /**


### PR DESCRIPTION
As an alternative to event-based capture of audio data, these changes allow the plugin to save audio directly to a file.

To enable this option, add a _fileUrl_ setting to the capture config passed into the _start_ method - e.g.
```
var fileUrl = cordova.file.dataDirectory + "audio.wav";
var captureCfg = {
  sampleRate: 16000,
  bufferSize: 8192,
  channels: 1,
  format: audioinput.FORMAT.PCM_16BIT,
  audioSourceType: audioinput.AUDIOSOURCE_TYPE.DEFAULT,
  fileUrl: fileUrl
};
audioinput.start(captureCfg);
```
When _stop_ is called, recording is stopped and the data written to the specified file, and then an 'audioinputfinished' event is raised, which includes the original file URL:
```
window.addEventListener('audioinputfinished', function(e) { 
  doSomethingWithFile(e.file);
}, false);
```

NB there is a [request for saving audio input to files](https://github.com/edimuj/cordova-plugin-audioinput/issues/27) - these changes don't exactly fulfil this request, as here the audio is saved to a file _instead of_ (rather than _as well as_) being passed in events, and the target format is _not_ the requested M4A. I have tested these changes with WAV files, as this is what my project requires.
