### PR TITLE
remove cordova-plugin-compat dependency for cordova-android version >= 6.3.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -18,8 +18,8 @@
     <js-module name="AudioInput" src="www/audioInputCapture.js">
         <clobbers target="audioinput"/>
     </js-module>
-
-    <dependency id="cordova-plugin-compat" version="^1.2.0"/>
+ <!-- cordova-plugin-compat is only needed for < android 6.3.0 -->
+   <!--  <dependency id="cordova-plugin-compat" version="^1.2.0"/>  -->
 
     <!-- android -->
     <platform name="android">


### PR DESCRIPTION
cordova-plugin-compat is only needed for < android 6.3.0.
Since Cordova-android 6.3.0 and upwards, the plugin is already included within android. (Reinstalling cordova-plugin-compat conflicts with gradle v4.1 and higher, and causes errors)