### PR TITLE
fix(iOS): preserve Bluetooth headset connection if present

### DIFF
--- a/src/ios/AudioReceiver.m
+++ b/src/ios/AudioReceiver.m
@@ -63,9 +63,14 @@ void HandleInputBuffer(void* inUserData,
 
         AVAudioSession* avSession = [AVAudioSession sharedInstance];
 
+        int avOptions = AVAudioSessionCategoryOptionMixWithOthers | AVAudioSessionCategoryOptionDefaultToSpeaker;
+        if([self isBTHeadsetConnected]) {
+            avOptions =  avOptions | AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+        }
+
         NSError *setCategoryError = nil;
         if (![avSession setCategory:AVAudioSessionCategoryPlayAndRecord
-         withOptions:AVAudioSessionCategoryOptionMixWithOthers | AVAudioSessionCategoryOptionDefaultToSpeaker
+         withOptions:avOptions
          error:&setCategoryError]) {
             // handle error?
         }
@@ -268,5 +273,22 @@ void HandleInputBuffer(void* inUserData,
     [self.delegate didFinish:file];
 }
 
+/**
+  Checks if a Bluethooth audio headset is connected
+  returns true if so
+*/
+- (Boolean) isBTHeadsetConnected {
+    AVAudioSessionRouteDescription *currentRoute = [[AVAudioSession sharedInstance] currentRoute];
+    for (AVAudioSessionPortDescription *port in currentRoute.outputs)
+    {
+        if ([port.portType isEqualToString:AVAudioSessionPortBluetoothA2DP] ||
+            [port.portType isEqualToString:AVAudioSessionPortBluetoothHFP])
+        {
+            return true;
+        }
+
+    }
+    return false;
+}
 
 @end


### PR DESCRIPTION
Hello,
this PR addresses an issue on iOS that happens whenever the user has a Bluetooth headset connected to the phone. 

The current implementation of `init()`  in `AudioReceiver.m` forces audio through the default speaker, causing the phone to disconnect the BT headset.

This PR modifies that logic by adding a check to inspect if a BT headset is connected and, if so, adding the relevant option flag to the AVSession.

It has been tested on iPhone 7 Plus, XR and 11 using iOS 14 and 15.