### PR TITLE
Fix Browser plugin target dir for Cordova 9+

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -72,7 +72,7 @@
         <js-module src="src/browser/AudioInputCaptureProxy.js" name="AudioInputCaptureProxy">
             <runs/>
         </js-module>
-        <asset src="src/browser/RecorderWorker.js" target=".">
+        <asset src="src/browser/RecorderWorker.js" target="./RecorderWorker.js">
             <runs/>
         </asset>
 


### PR DESCRIPTION
This resolves the issue where installation for browser or browser compatible platform like electron for MacOSX or Linux based installations.

Failed to install 'cordova-plugin-audioinput': Error: Uh oh!
Cannot overwrite directory '/Users/xxx/Documents/GitHub/Project/platforms/electron/platform_www' with non-directory '/Users/xxx/Documents/GitHub/Project/plugins/cordova-plugin-audioinput/src/browser/RecorderWorker.js'.